### PR TITLE
构建: 优化cd命令路径，确保在github actions中正确执行

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,10 +28,10 @@ jobs:
 
       - name: Build C binary
         run: |
-          cd pkg/audio/slik
+          cd ./pkg/audio/slik
           make
 
       - name: Build go binary
         run: |
-          CGO_ENABLED=1 GOARCH=arm64 go build -v -o chat-copilot_arm64 cmd/...
-          CGO_ENABLED=1 GOARCH=amd64 go build -v -o chat-copilot_amd64 cmd/...
+          CGO_ENABLED=1 GOARCH=arm64 go build -v -o chat-copilot_arm64 ./cmd/...
+          CGO_ENABLED=1 GOARCH=amd64 go build -v -o chat-copilot_amd64 ./cmd/...


### PR DESCRIPTION
在github actions的构建流程中，优化了cd命令的路径表达方式，使用了相对路径
"./pkg/audio/slik"和"./cmd"来确保在不同的工作环境中都能准确地定位到
需要构建的目录。