### PR TITLE
chore(github-actions): 移除fetch-tags选项以优化构建过程

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,6 @@ jobs:
         with:
           show-progress: true
           submodules: true
-          fetch-tags: true
 
       - name: Set up Go
         uses: actions/setup-go@v5


### PR DESCRIPTION
在github-actions的release工作流中，移除了fetch-tags选项以优化构建过程，减少不必要的时间消耗。